### PR TITLE
Fix message with cutting error message

### DIFF
--- a/src/Clients/AbstractMindboxClient.php
+++ b/src/Clients/AbstractMindboxClient.php
@@ -285,7 +285,7 @@ abstract class AbstractMindboxClient
                 $body = $context['response']['body'];
                 $arBody  = json_decode($body, true);
                 if ($arBody) {
-                    $message = \trim(\array_slice(\explode(':', $arBody['errorMessage'], 2), -1)[0]);
+                    $message = $arBody['errorMessage'];
                 } else {
                     $message = 'Bad request';
                 }


### PR DESCRIPTION
Сообщение об ошибке обрезается по ':', это приводит к тому, что обрезается значимая часть сообщения и невозможно понять, где именно ошибка, данный PR исправляет эту проблему.

Пример:
Было: " Поле должно быть заполнено."
Стало: "/emailMailing/customParameters/EventLink: Поле должно быть заполнено."