### PR TITLE
Quick fork of HttpClientFactory to use own HttpClient.

### DIFF
--- a/src/HttpClients/HttpClientFactory.php
+++ b/src/HttpClients/HttpClientFactory.php
@@ -43,6 +43,12 @@ class HttpClientFactory
             case 'stream':
                 return new StreamHttpClient(new MindboxStream(), $timeout);
             default:
+                if (class_exists($handlerName)
+                    && is_a($handlerName, CurlHttpClient::class, true)
+                ) {
+                    return new $handlerName(new MindboxCurl(), $timeout);
+                }
+
                 throw new MindboxConfigException('The http client handler must be set to "curl", "stream"');
         }
     }


### PR DESCRIPTION
Возможность использовать свой собственный http-клиент, 

решение на скорую руку

```
class CustomMindboxHttpClient extends \Mindbox\HttpClients\CurlHttpClient {
// own logic
}

...
$config['httpClient'] = CustomMindboxHttpClient::class;
...
$mb = new \Mindbox\Mindbox($config);
```